### PR TITLE
#12 fix: 원장 승인 없이 학생/학부모가 로그인후 페이지 접속 불가

### DIFF
--- a/lib/LoginPage.dart
+++ b/lib/LoginPage.dart
@@ -1,4 +1,5 @@
 import 'package:academy_manager/AfterLogin.dart';
+import 'package:academy_manager/AfterSignup.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -158,6 +159,13 @@ class _LoginpageState extends State<LoginPage> {
                         );
                       }
                       else {
+                        Fluttertoast.showToast(
+                          msg: "로그인중...",
+                          backgroundColor: Colors.grey,
+                          fontSize: 16,
+                          timeInSecForIosWeb: 1,
+                          gravity: ToastGravity.BOTTOM,
+                        );
                         // id, pw를 서버에 보내 맞는 정보인지 확인.
                         var response;
                         try {
@@ -174,19 +182,21 @@ class _LoginpageState extends State<LoginPage> {
                           storage.delete(key: 'refreshToken');
                           storage.write(key: "refreshToken", value: response.headers['set-cookie'][0]);
 
-                          Fluttertoast.showToast(
-                              msg: "로그인중...",
-                            backgroundColor: Colors.grey,
-                            fontSize: 16,
-                            timeInSecForIosWeb: 1,
-                            gravity: ToastGravity.BOTTOM,
-                          );
-
-                          Navigator.pushReplacement(context,
-                            MaterialPageRoute(
-                                builder: (context)=> AfterLoginPage(),
-                              ),
-                          );
+                          if(response.data['userStatus'] != null) {
+                            if (response.data['userStatus']['status'] == "ACTIVE")
+                              Navigator.pushReplacement(context,
+                                MaterialPageRoute(
+                                  builder: (context) => AfterLoginPage(),
+                                ),
+                              );
+                          }
+                          else{
+                            //var response = dio.get('/user/{user_id}'); //TODO: 백엔드 개발중
+                            Navigator.pushReplacement(
+                                context,
+                                MaterialPageRoute(builder: (context) => AfterSignUp(name: "Minsoo Kim", role: 1, isKey: false)) // name과 role은 백엔드에서 개발이 완료되면 추가 예정
+                            );
+                          }
                         } catch (err) {
 
                         }


### PR DESCRIPTION
## #️⃣연관된 이슈

#12 

## 📝작업 내용

백엔드에서 받은 response에 있는 userState의 null 여부를 검사하고 userState안의 "state"가 "ACTIVATE"이면 로그인후 화면으로 전환되고 "userState"가 null이면 학원키 등록 창으로 이동한다.
기존에 학원키 등록 여부에 상관 없이 학원키 등록 창으로 이동하고 중복으로 등록을 시도하면 백엔드에서 "이미 등록요청된 유저입니다."에러를 반환한다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
