### PR TITLE
#23 feat: 회원탈퇴 버튼을 앱설정으로 이동

### DIFF
--- a/lib/AppSettings.dart
+++ b/lib/AppSettings.dart
@@ -1,20 +1,54 @@
 import 'package:academy_manager/AppBar.dart';  // AppBar.dart 파일에서 MyAppBar를 import
+import 'package:academy_manager/MyDio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:academy_manager/main.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 
 class AppSettings extends StatefulWidget {
-
 
   @override
   _AppSettingsState createState() => _AppSettingsState();
 }
 
 class _AppSettingsState extends State<AppSettings> {
+  String? id, accessToken;
+
+  String name="", email="";
+
+  static final dio = new MyDio();
+
+  static final storage = new FlutterSecureStorage();
+  @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+
+    WidgetsBinding.instance.addPostFrameCallback((_){
+      _asyncMethod();
+    });
+  }
+
+  _asyncMethod() async{
+    id = await storage.read(key: 'id');
+    accessToken = await storage.read(key: 'accessToken');
+
+    dio.addResponseInterceptor('Authorization', 'Bear '+accessToken.toString());
+
+    var response = await dio.get('/user/'+id.toString()+'/basic-info');
+    setState(() {
+      name = response.data['user_name'];
+      email = response.data['email'];
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
+    dio.addErrorInterceptor(context);
     return Scaffold(
       appBar: MyAppBar().build(context),
-      drawer: MenuDrawer(name: '현우진', email: 'example@gmail.com', subjects: ['수학']),
+      drawer: MenuDrawer(name: name, email: email, subjects: ['수학']),
       body: Padding(
         padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 10.h),
         child: Column(
@@ -73,11 +107,26 @@ class _AppSettingsState extends State<AppSettings> {
               ),
               onTap: () {
                 // 탈퇴하기 클릭 시 동작
+                delete();
               },
             ),
           ],
         ),
       ),
     );
+  }
+
+  delete() async {
+    dio.addResponseInterceptor('Content-Type', 'application/json');
+    try {
+      var response = await dio.delete('/user/'+id.toString());
+      if(response.statusCode == 200){
+        Fluttertoast.showToast(msg: "정상탈퇴 되었습니다.");
+        Navigator.pushAndRemoveUntil(context, MaterialPageRoute(builder: (context)=>MyApp()), (route)=>false);
+      }
+    } catch (err) {
+      print(err);
+      Navigator.pop(context);
+    }
   }
 }

--- a/lib/MyPage.dart
+++ b/lib/MyPage.dart
@@ -87,7 +87,7 @@ class _MyPageState extends State<MyPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: MyAppBar().build(context),
+      appBar: MyAppBar(isSettings: true,).build(context),
       drawer: MenuDrawer(name: name.toString(), email: email.toString(), subjects: ['수학']),
       body: Padding(
         padding: EdgeInsets.symmetric(horizontal: 20.w, vertical: 10.h),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -324,18 +324,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -364,15 +364,15 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
     version: "1.12.0"
@@ -505,10 +505,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -529,10 +529,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.5"
+    version: "14.2.1"
   web:
     dependency: transitive
     description:


### PR DESCRIPTION
## #️⃣연관된 이슈

> #23 

## 📝작업 내용

- 회원정보 수정 페이지에 있던 회원탈퇴 버튼을 앱설정에 있는 회원탈퇴 버튼으로 기능 이동.
- 회원정보 수정 페이지에 있던 회원탈퇴 버튼 삭제

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
