### PR TITLE
#27 student parent

### DIFF
--- a/lib/SignupPage.dart
+++ b/lib/SignupPage.dart
@@ -48,6 +48,9 @@ class _SignupPageState extends State<SignupPage> {
   // 학생/학부모 구분
   Role role = Role.STUDENT;
 
+  // 학원 초대키 hint text
+  String? hintText = '학원초대키';
+
   @override
   void initState() {
     super.initState();
@@ -113,6 +116,7 @@ class _SignupPageState extends State<SignupPage> {
                               onChanged: (value){
                                 setState(() {
                                   role = Role.STUDENT;
+                                  hintText = "학원초대키";
                                 });
                               }),
                         ),
@@ -126,6 +130,7 @@ class _SignupPageState extends State<SignupPage> {
                               onChanged: (value){
                                 setState(() {
                                   role = Role.PARENT;
+                                  hintText = "학생아이디";
                                 });
                               }),
                         )
@@ -439,9 +444,16 @@ class _SignupPageState extends State<SignupPage> {
                       child: Padding(
                         padding: EdgeInsets.only(top: midSize),
                         child: TextFormField(
+                          validator: (value){
+                            if(role == Role.PARENT && value!.isEmpty){
+                              return "학생 아이디를 입력하세요";
+                            }else{
+                              return null;
+                            }
+                          },
                           controller: controllers[6],
-                          decoration: const InputDecoration(
-                            hintText: "학원초대키",
+                          decoration: InputDecoration(
+                            hintText: hintText,
                           ),
                           focusNode: _keyFocusNode,
                           onFieldSubmitted: (_) {},

--- a/lib/SignupPage.dart
+++ b/lib/SignupPage.dart
@@ -516,6 +516,7 @@ class _SignupPageState extends State<SignupPage> {
                                         (route) => false,
                                   );
                                 } else {
+                                  // TODO: 학생일 때는 아래 코드 그대로 사용하고 학부모일 때는 다른 api 사용.
                                   // 회원가입 후 자동으로 등록신청
                                   // 회원가입 시 받은 아이디, 비밀번호로 로그인 후 토큰 값을 받아 진행.
                                   // 로그인

--- a/lib/SignupPage.dart
+++ b/lib/SignupPage.dart
@@ -6,6 +6,8 @@ import 'package:flutter_screenutil/flutter_screenutil.dart'; // 화면 사이즈
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 
+enum Role {STUDENT, PARENT}
+
 class SignupPage extends StatefulWidget {
   const SignupPage({super.key});
 
@@ -42,6 +44,9 @@ class _SignupPageState extends State<SignupPage> {
 
   // http 통신을 위한 dio
   var dio;
+
+  // 학생/학부모 구분
+  Role role = Role.STUDENT;
 
   @override
   void initState() {
@@ -94,6 +99,37 @@ class _SignupPageState extends State<SignupPage> {
                           fontSize: 40.sp,
                         ),
                       ),
+                    ),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                      children: [
+                        SizedBox(
+                          width: 130.w,
+                          height: 51.h,
+                          child: RadioListTile(
+                            title: const Text("학생"),
+                              value: Role.STUDENT,
+                              groupValue: role,
+                              onChanged: (value){
+                                setState(() {
+                                  role = Role.STUDENT;
+                                });
+                              }),
+                        ),
+                        SizedBox(
+                          width: 140.w,
+                          height: 51.h,
+                          child: RadioListTile(
+                              title: const Text("학부모"),
+                              value: Role.PARENT,
+                              groupValue: role,
+                              onChanged: (value){
+                                setState(() {
+                                  role = Role.PARENT;
+                                });
+                              }),
+                        )
+                      ],
                     ),
                     SizedBox(
                       width: 342.w,
@@ -450,7 +486,7 @@ class _SignupPageState extends State<SignupPage> {
                                     "password": values[2],
                                     "phone_number": values[4],
                                     "birth_date": values[5] + "T00:00:00Z",
-                                    "role": "STUDENT",
+                                    "role" : (role == Role.STUDENT)? "STUDENT" : "PARENT"
                                   });
                               if (response.statusCode == 201) {
                                 // 회원가입 성공
@@ -487,7 +523,7 @@ class _SignupPageState extends State<SignupPage> {
                                   response = await dio.post('/registeration/request/user', data: {
                                     "user_id" : values[1],
                                     "academy_key" : values[6],
-                                    "role" : "STUDENT"
+                                    "role" : (role == Role.STUDENT)? "STUDENT" : "PARENT"
                                   });
                                   if(response.statusCode == 201){
                                     Fluttertoast.showToast(

--- a/lib/SignupPage.dart
+++ b/lib/SignupPage.dart
@@ -107,7 +107,7 @@ class _SignupPageState extends State<SignupPage> {
                       mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                       children: [
                         SizedBox(
-                          width: 130.w,
+                          width: 160.w,
                           height: 51.h,
                           child: RadioListTile(
                             title: const Text("학생"),
@@ -121,7 +121,7 @@ class _SignupPageState extends State<SignupPage> {
                               }),
                         ),
                         SizedBox(
-                          width: 140.w,
+                          width: 160.w,
                           height: 51.h,
                           child: RadioListTile(
                               title: const Text("학부모"),


### PR DESCRIPTION
## #️⃣연관된 이슈

#27 

## 📝작업 내용

회원가입 시 상단에 학생, 학부모선택 라디오버튼을 추가.
학부모를 선택 시 맨 하단 학원초대키 부분이 학생아이디 입력으로 바뀜.
학부모로 회원가입 시 학생아이디란을 필수 입력으로 하고 추후 백엔드에서 api를 추가하면 연동할 예정

### 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/4f76bc29-8548-454b-b7f7-218e76eae06a" width="300px">


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
